### PR TITLE
Setup linking between inspections/violations/case_histories and cases

### DIFF
--- a/app/controllers/case_histories_controller.rb
+++ b/app/controllers/case_histories_controller.rb
@@ -3,12 +3,22 @@ class CaseHistoriesController < ApplicationController
 
   def index
     socrata = Socrata.new
-    @case_histories = socrata.paginate(socrata.case_history_dataset_id, params[:page], {'$order': 'date, case_number'})
+    params[:filters] ||= {}
+    opts = {'$order': 'date, case_number'}
+    if params[:filters][:case]
+      opts['$where'] = "case_number = '#{params[:filters][:case]}'"
+    end
+    @case_histories = socrata.paginate(socrata.case_history_dataset_id, params[:page], opts)
   end
 
   def show
     socrata = Socrata.new
-    @case_history = socrata.client.get(socrata.case_history_dataset_id, {'$where': "case_number = '#{params[:id]}'"}).first
+    case_number = params[:id].split('*').first
+    case_history_sakey = params[:id].split('*')[1]
+    opts = {
+      '$where': "case_number = '#{case_number}' and case_history_sakey='#{case_history_sakey}'"
+    }
+    @case_history = socrata.client.get(socrata.case_history_dataset_id, opts).first
   end
 
 end

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -3,12 +3,37 @@ class InspectionsController < ApplicationController
 
   def index
     socrata = Socrata.new
-    @inspections = socrata.paginate(socrata.inspection_dataset_id, params[:page], {'$order': 'inspection_date, case_number'})
+    params[:filters] ||= {}
+    opts = {'$order': 'inspection_date, case_number'}
+    if params[:filters][:case]
+      opts['$where'] = "case_number = '#{params[:filters][:case]}'"
+    end
+    @inspections = socrata.paginate(socrata.inspection_dataset_id, params[:page], opts)
   end
 
   def show
     socrata = Socrata.new
-    @inspection = socrata.client.get(socrata.inspection_dataset_id, {'$where': "case_number = '#{params[:id]}'"}).first
+    case_number = params[:id].split('*').first
+    entry_date = params[:id].split('*')[1]
+    inspection_date = params[:id].split('*')[2]
+
+    # For some reason, ruby won't let you do something like this:
+    #  opts = {'$where': 'foo'}
+    #  opts['$where'] += ' and bar'
+    #
+    # It gives a whiny nil error when you try the += command.
+    # The workaround is to build a where clause string and add to
+    # opts at the end.
+    where = "case_number = '#{case_number}'"
+
+    if entry_date and entry_date = entry_date.to_i and entry_date > 0
+      where += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
+    end
+    if inspection_date and inspection_date = inspection_date.to_i and inspection_date > 0
+      where += " and inspection_date = '#{Time.at(inspection_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
+    end
+    opts = {'$where': where}
+    @inspection = socrata.client.get(socrata.inspection_dataset_id, opts).first
   end
 
 end

--- a/app/controllers/violations_controller.rb
+++ b/app/controllers/violations_controller.rb
@@ -3,12 +3,37 @@ class ViolationsController < ApplicationController
 
   def index
     socrata = Socrata.new
-    @violations = socrata.paginate(socrata.violation_dataset_id, params[:page], {'$order': 'issued_date, case_number'})
+    params[:filters] ||= {}
+    opts = {'$order': 'issued_date, case_number'}
+    if params[:filters][:case]
+      opts['$where'] = "case_number = '#{params[:filters][:case]}'"
+    end
+    @violations = socrata.paginate(socrata.violation_dataset_id, params[:page], opts)
   end
 
   def show
     socrata = Socrata.new
-    @violation = socrata.client.get(socrata.violation_dataset_id, {'$where': "case_number = '#{params[:id]}'"}).first
+    case_number = params[:id].split('*').first
+    entry_date = params[:id].split('*')[1]
+    violation_code = params[:id].split('*')[2]
+
+    # For some reason, ruby won't let you do something like this:
+    #  opts = {'$where': 'foo'}
+    #  opts['$where'] += ' and bar'
+    #
+    # It gives a whiny nil error when you try the += command.
+    # The workaround is to build a where clause string and add to
+    # opts at the end.
+    where = "case_number = '#{case_number}'"
+
+    if entry_date and entry_date = entry_date.to_i and entry_date > 0
+      where += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
+    end
+    if violation_code and violation_code != ''
+      where += " and violation_code = '#{violation_code}'"
+    end
+    opts = {'$where': where}
+    @violation = socrata.client.get(socrata.violation_dataset_id, opts).first
   end
 
 end

--- a/app/helpers/case_histories_helper.rb
+++ b/app/helpers/case_histories_helper.rb
@@ -1,2 +1,7 @@
 module CaseHistoriesHelper
+
+  def unique_case_history_id(case_history)
+    "#{case_history.case_number}*#{case_history.case_history_sakey}"
+  end
+
 end

--- a/app/helpers/inspections_helper.rb
+++ b/app/helpers/inspections_helper.rb
@@ -1,2 +1,8 @@
 module InspectionsHelper
+
+  def unique_inspection_id(inspection)
+    entry_date = Time.parse inspection.entry_date
+    inspection_date = Time.parse inspection.inspection_date
+    "#{inspection.case_number}*#{entry_date ? entry_date.to_i : nil}*#{inspection_date ? inspection_date.to_i : nil}"
+  end
 end

--- a/app/helpers/violations_helper.rb
+++ b/app/helpers/violations_helper.rb
@@ -1,2 +1,8 @@
 module ViolationsHelper
+
+  def unique_violation_id(violation)
+    entry_date = Time.parse violation.entry_date
+    "#{violation.case_number}*#{entry_date ? entry_date.to_i : nil}*#{violation.violation_code}"
+  end
+
 end

--- a/app/views/case_histories/index.html.erb
+++ b/app/views/case_histories/index.html.erb
@@ -7,8 +7,8 @@
   </thead>
   <tbody>
     <% @case_histories.compact.each do |case_history| %>
-      <tr data-case-number="<%= case_history.case_number -%>">
-        <td><%= link_to case_history.case_number, {action: :show, id: case_history.case_number} %></td>
+      <tr data-unique-id="<%= unique_case_history_id case_history -%>">
+        <td><%= link_to "#{case_history.case_number} - ##{case_history.case_history_sakey}", case_history_path(unique_case_history_id(case_history)) %></td>
         <td><%= Date.parse(case_history.date) %></td>
         <td><%= case_history.action %></td>
       </tr>

--- a/app/views/case_histories/show.html.erb
+++ b/app/views/case_histories/show.html.erb
@@ -1,3 +1,4 @@
 <h1>Case History Detail</h1>
 <pre><%= @case_history.to_yaml %></pre>
+<%= link_to 'View Case', case_path(@case_history.case_number) %><br />
 <%= link_to 'Browse Case Histories', case_histories_path %>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -8,7 +8,7 @@
   <tbody>
     <% @cases.compact.each do |item| %>
       <tr data-item-number="<%= item.case_number -%>">
-        <td><%= link_to item.case_number, {action: :show, id: item.case_number} %></td>
+        <td><%= link_to item.case_number, case_path(item.case_number) %></td>
         <td><%= Date.parse(item.entry_date) %></td>
         <td><%= item.case_notes %></td>
       </tr>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,4 +1,5 @@
 <h1>Case Detail</h1>
 <pre><%= @case.to_yaml %></pre>
 <%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.case_number}) %><br />
+<%= link_to 'Case Violations', violations_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Browse Cases', cases_path %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -2,4 +2,5 @@
 <pre><%= @case.to_yaml %></pre>
 <%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Case Violations', violations_path(filters: {'case': @case.case_number}) %><br />
+<%= link_to 'Case Histories', case_histories_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Browse Cases', cases_path %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,3 +1,4 @@
 <h1>Case Detail</h1>
 <pre><%= @case.to_yaml %></pre>
+<%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Browse Cases', cases_path %>

--- a/app/views/inspections/index.html.erb
+++ b/app/views/inspections/index.html.erb
@@ -7,8 +7,8 @@
   </thead>
   <tbody>
     <% @inspections.compact.each do |inspection| %>
-      <tr data-case-number="<%= inspection.case_number -%>">
-        <td><%= link_to inspection.case_number, {action: :show, id: inspection.case_number} %></td>
+      <tr data-unique-id="<%= unique_inspection_id(inspection) -%>">
+        <td><%= link_to inspection.case_number, inspection_path(unique_inspection_id(inspection)) %></td>
         <td><%= Date.parse(inspection.inspection_date) %></td>
         <td><%= inspection.inspection_type_desc %></td>
       </tr>

--- a/app/views/inspections/show.html.erb
+++ b/app/views/inspections/show.html.erb
@@ -1,3 +1,4 @@
 <h1>Inspection Detail</h1>
 <pre><%= @inspection.to_yaml %></pre>
+<%= link_to 'View Case', case_path(@inspection.case_number) %><br />
 <%= link_to 'Browse Inspections', inspections_path %>

--- a/app/views/violations/index.html.erb
+++ b/app/views/violations/index.html.erb
@@ -7,8 +7,8 @@
   </thead>
   <tbody>
     <% @violations.compact.each do |violation| %>
-      <tr data-case-number="<%= violation.case_number -%>">
-        <td><%= link_to violation.case_number, {action: :show, id: violation.case_number} %></td>
+      <tr data-unique-id="<%= unique_violation_id(violation) -%>">
+        <td><%= link_to violation.case_number, violation_path(unique_violation_id(violation)) %></td>
         <td><%= Date.parse(violation.issued_date) %></td>
         <td><%= violation.violation_description %></td>
       </tr>

--- a/app/views/violations/show.html.erb
+++ b/app/views/violations/show.html.erb
@@ -1,3 +1,4 @@
 <h1>Violation Detail</h1>
 <pre><%= @violation.to_yaml %></pre>
+<%= link_to 'View Case', case_path(@violation.case_number) %><br />
 <%= link_to 'Browse Violations', violations_path %>

--- a/lib/socrata.rb
+++ b/lib/socrata.rb
@@ -47,7 +47,11 @@ class Socrata
     arr += client.get(dataset_id, opts)
 
     # if there are more pages after the current one, add more nil values
-    total_record_count = client.get(dataset_id,{'$select': 'count(*)'})[0]['count'].to_i
+    opts2 = {'$select': 'count(*)'}
+    if opts['$where']
+      opts2['$where'] = opts['$where']
+    end
+    total_record_count = client.get(dataset_id, opts2)[0]['count'].to_i
     if total_record_count > page * Kaminari.config.default_per_page
       arr += Array.new([total_record_count - (page * Kaminari.config.default_per_page), 0].max)
     end

--- a/test/controllers/case_histories_controller_test.rb
+++ b/test/controllers/case_histories_controller_test.rb
@@ -1,30 +1,43 @@
 require 'test_helper'
-
+require File.expand_path(Rails.root)+'/app/helpers/inspections_helper'
+require File.expand_path(Rails.root)+'/lib/socrata'
 class CaseHistoriesControllerTest < ActionController::TestCase
+  include CaseHistoriesHelper
 
   test "should get index" do
-    get :index
-    assert_response :success
-    assert assigns['case_histories'].kind_of?(Array)
-    assert_not_equal 0, assigns['case_histories'].size
-    assert_select "table tbody" do
-      assigns['case_histories'].each do |case_history|
-        assert_select "tr[data-case-number='#{case_history.case_number}']" do
-          expected_url = "/case_histories/#{case_history.case_number}"
-          assert_select "td a[href='#{expected_url}']", text: case_history.case_number
+    socrata = Socrata.new
+    [false,true].each do |filter_by_case|
+      params = {}
+      if filter_by_case
+        case_history = socrata.client.get(socrata.case_history_dataset_id,{'$limit': 1}).first
+        expected = socrata.client.get(socrata.case_dataset_id, {'$where': "case_number = '#{case_history.case_number}'"}).first
+        params[:filters] = {'case': expected.case_number}
+      end
+      get :index, params
+      assert_response :success
+      assert assigns['case_histories'].kind_of?(Array)
+      assert_not_equal 0, assigns['case_histories'].size
+      assert_select "table tbody" do
+        assigns['case_histories'].each do |case_history|
+          assert_select "tr[data-unique-id='#{unique_case_history_id(case_history)}']" do
+            assert_select "td a[href='#{case_history_path(unique_case_history_id(case_history))}']", text: "#{case_history.case_number} - ##{case_history.case_history_sakey}"
+            if filter_by_case
+              assert_equal expected.case_number, case_history.case_number
+            end
+          end
         end
       end
     end
   end
 
   test "should get show" do
-    require File.expand_path(Rails.root)+'/lib/socrata'
     socrata = Socrata.new
     expected = socrata.client.get(socrata.case_history_dataset_id,{'$limit': 1}).first
-    get :show, {id: expected.case_number}
+    get :show, {id: unique_case_history_id(expected)}
     assert_response :success
     assert assigns['case_history'].kind_of?(Hashie::Mash)
     assert_equal expected.case_number, assigns['case_history'].case_number
+    assert_select "a[href='#{case_path(assigns['case_history'].case_number)}']", text: 'View Case'
     assert_select "a[href='#{case_histories_path}']"
   end
 

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -25,6 +25,7 @@ class CasesControllerTest < ActionController::TestCase
     assert assigns['case'].kind_of?(Hashie::Mash)
     assert_equal expected.case_number, assigns['case'].case_number
     assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Inspections'
+    assert_select "a[href='#{violations_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Violations'
     assert_select "a[href='#{cases_path}']"
   end
 

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -26,6 +26,7 @@ class CasesControllerTest < ActionController::TestCase
     assert_equal expected.case_number, assigns['case'].case_number
     assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Inspections'
     assert_select "a[href='#{violations_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Violations'
+    assert_select "a[href='#{case_histories_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Histories'
     assert_select "a[href='#{cases_path}']"
   end
 

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -10,8 +10,7 @@ class CasesControllerTest < ActionController::TestCase
     assert_select "table tbody" do
       assigns['cases'].each do |item|
         assert_select "tr[data-item-number='#{item.case_number}']" do
-          expected_url = "/cases/#{item.case_number}"
-          assert_select "td a[href='#{expected_url}']", text: item.case_number
+          assert_select "td a[href='#{case_path(item.case_number)}']", text: item.case_number
         end
       end
     end
@@ -25,6 +24,7 @@ class CasesControllerTest < ActionController::TestCase
     assert_response :success
     assert assigns['case'].kind_of?(Hashie::Mash)
     assert_equal expected.case_number, assigns['case'].case_number
+    assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Inspections'
     assert_select "a[href='#{cases_path}']"
   end
 

--- a/test/controllers/inspections_controller_test.rb
+++ b/test/controllers/inspections_controller_test.rb
@@ -5,8 +5,8 @@ class InspectionsControllerTest < ActionController::TestCase
   include InspectionsHelper
 
   test "should get index" do
+    socrata = Socrata.new
     [false,true].each do |filter_by_case|
-      socrata = Socrata.new
       params = {}
       if filter_by_case
         expected = socrata.client.get(socrata.case_dataset_id, {'$limit': 1}).first

--- a/test/controllers/inspections_controller_test.rb
+++ b/test/controllers/inspections_controller_test.rb
@@ -1,29 +1,42 @@
 require 'test_helper'
+require File.expand_path(Rails.root)+'/app/helpers/inspections_helper'
+require File.expand_path(Rails.root)+'/lib/socrata'
 class InspectionsControllerTest < ActionController::TestCase
+  include InspectionsHelper
 
   test "should get index" do
-    get :index
-    assert_response :success
-    assert assigns['inspections'].kind_of?(Array)
-    assert_not_equal 0, assigns['inspections'].size
-    assert_select "table tbody" do
-      assigns['inspections'].each do |inspection|
-        assert_select "tr[data-case-number='#{inspection.case_number}']" do
-          expected_url = "/inspections/#{inspection.case_number}"
-          assert_select "td a[href='#{expected_url}']", text: inspection.case_number
+    [false,true].each do |filter_by_case|
+      socrata = Socrata.new
+      params = {}
+      if filter_by_case
+        expected = socrata.client.get(socrata.case_dataset_id, {'$limit': 1}).first
+        params[:filters] = {'case': expected.case_number}
+      end
+      get :index, params
+      assert_response :success
+      assert assigns['inspections'].kind_of?(Array)
+      assert_not_equal 0, assigns['inspections'].size
+      assert_select "table tbody" do
+        assigns['inspections'].each do |inspection|
+          assert_select "tr[data-unique-id='#{unique_inspection_id(inspection)}']" do
+            assert_select "td a[href='#{inspection_path(unique_inspection_id(inspection))}']", text: inspection.case_number
+            if filter_by_case
+              assert_equal expected.case_number, inspection.case_number
+            end
+          end
         end
       end
     end
   end
 
   test "should get show" do
-    require File.expand_path(Rails.root)+'/lib/socrata'
     socrata = Socrata.new
-    expected = socrata.client.get(socrata.inspection_dataset_id,{'$limit': 1}).first
-    get :show, {id: expected.case_number}
+    expected = socrata.client.get(socrata.inspection_dataset_id, {'$limit': 1}).first
+    get :show, {id: unique_inspection_id(expected)}
     assert_response :success
     assert assigns['inspection'].kind_of?(Hashie::Mash)
     assert_equal expected.case_number, assigns['inspection'].case_number
+    assert_select "a[href='#{case_path(assigns['inspection'].case_number)}']", text: 'View Case'
     assert_select "a[href='#{inspections_path}']"
   end
 

--- a/test/controllers/violations_controller_test.rb
+++ b/test/controllers/violations_controller_test.rb
@@ -1,30 +1,43 @@
 require 'test_helper'
-
+require File.expand_path(Rails.root)+'/app/helpers/violations_helper'
+require File.expand_path(Rails.root)+'/lib/socrata'
 class ViolationsControllerTest < ActionController::TestCase
+  include ViolationsHelper
 
   test "should get index" do
-    get :index
-    assert_response :success
-    assert assigns['violations'].kind_of?(Array)
-    assert_not_equal 0, assigns['violations'].size
-    assert_select "table tbody" do
-      assigns['violations'].each do |violation|
-        assert_select "tr[data-case-number='#{violation.case_number}']" do
-          expected_url = "/violations/#{violation.case_number}"
-          assert_select "td a[href='#{expected_url}']", text: violation.case_number
+    [false,true].each do |filter_by_case|
+      socrata = Socrata.new
+      params = {}
+      if filter_by_case
+        violation = socrata.client.get(socrata.violation_dataset_id,{'$limit': 1}).first
+        expected = socrata.client.get(socrata.case_dataset_id, {'$where': "case_number = '#{violation.case_number}'"}).first
+        params[:filters] = {'case': expected.case_number}
+      end
+      get :index, params
+      assert_response :success
+      assert assigns['violations'].kind_of?(Array)
+      assert_not_equal 0, assigns['violations'].size
+      assert_select "table tbody" do
+        assigns['violations'].each do |violation|
+          assert_select "tr[data-unique-id='#{unique_violation_id(violation)}']" do
+            assert_select "td a[href='#{violation_path(unique_violation_id(violation))}']", text: violation.case_number
+            if filter_by_case
+              assert_equal expected.case_number, violation.case_number
+            end
+          end
         end
       end
     end
   end
 
   test "should get show" do
-    require File.expand_path(Rails.root)+'/lib/socrata'
     socrata = Socrata.new
     expected = socrata.client.get(socrata.violation_dataset_id,{'$limit': 1}).first
-    get :show, {id: expected.case_number}
+    get :show, {id: unique_violation_id(expected)}
     assert_response :success
     assert assigns['violation'].kind_of?(Hashie::Mash)
     assert_equal expected.case_number, assigns['violation'].case_number
+    assert_select "a[href='#{case_path(assigns['violation'].case_number)}']", text: 'View Case'
     assert_select "a[href='#{violations_path}']"
   end
 

--- a/test/controllers/violations_controller_test.rb
+++ b/test/controllers/violations_controller_test.rb
@@ -5,8 +5,8 @@ class ViolationsControllerTest < ActionController::TestCase
   include ViolationsHelper
 
   test "should get index" do
+    socrata = Socrata.new
     [false,true].each do |filter_by_case|
-      socrata = Socrata.new
       params = {}
       if filter_by_case
         violation = socrata.client.get(socrata.violation_dataset_id,{'$limit': 1}).first

--- a/test/helpers/case_histories_helper_test.rb
+++ b/test/helpers/case_histories_helper_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+class CaseHistoriesHelperTest < ActionView::TestCase
+  include CaseHistoriesHelper
+
+  test "unique_case_history_id" do
+    require File.expand_path(Rails.root)+'/lib/socrata'
+    socrata = Socrata.new
+    case_history = socrata.client.get(socrata.case_history_dataset_id,{'$limit': 1}).first
+    expected = "#{case_history.case_number}*#{case_history.case_history_sakey}"
+    assert_equal expected, unique_case_history_id(case_history)
+  end
+end

--- a/test/helpers/inspections_helper_test.rb
+++ b/test/helpers/inspections_helper_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+class InspectionsHelperTest < ActionView::TestCase
+  include InspectionsHelper
+
+  test "unique_inspection_id" do
+    require File.expand_path(Rails.root)+'/lib/socrata'
+    socrata = Socrata.new
+    inspection = socrata.client.get(socrata.inspection_dataset_id,{'$limit': 1}).first
+    entry_date = Time.parse inspection.entry_date
+    inspection_date = Time.parse inspection.inspection_date
+    expected = "#{inspection.case_number}*#{entry_date ? entry_date.to_i : nil}*#{inspection_date ? inspection_date.to_i : nil}"
+    assert_equal expected, unique_inspection_id(inspection)
+  end
+end

--- a/test/helpers/violations_helper_test.rb
+++ b/test/helpers/violations_helper_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+class ViolationsHelperTest < ActionView::TestCase
+  include ViolationsHelper
+
+  test "unique_violation_id" do
+    require File.expand_path(Rails.root)+'/lib/socrata'
+    socrata = Socrata.new
+    violation = socrata.client.get(socrata.violation_dataset_id,{'$limit': 1}).first
+    entry_date = Time.parse violation.entry_date
+    expected = "#{violation.case_number}*#{entry_date ? entry_date.to_i : nil}*#{violation.violation_code}"
+    assert_equal expected, unique_violation_id(violation)
+  end
+end


### PR DESCRIPTION
`cases#show` has a link to `inspections#index` filtered for the case (added a filtering option to `inspections#index`).

`inspections#show` has a link to `cases#show`.

Use a composite id to fake a primary key id for `inspections`.

-------------

`cases#show` has a link to `violations#index` filtered for the case (added a filtering option to `violations#index`).

`violations#show` has a link to `cases#show`.

Use a composite id to fake a primary key id for `violations`.

-------------

`cases#show` has a link to `case_histories#index` filtered for the case (added a filtering option to `case_histories#index`).

`case_histories#show` has a link to `cases#show`.

Use a composite id to fake a primary key id for `case_histories`.