### PR TITLE
Use redis to cache controller responses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,9 @@ gem 'bourbon';
 gem 'neat';
 gem 'bitters';
 
+# redis
+gem 'redis-rails'
+
 group :development, :test do
   gem 'byebug'
   gem 'web-console', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -208,6 +208,23 @@ GEM
       ffi (>= 0.5.0)
     rdoc (4.2.0)
       json (~> 1.4)
+    redis (3.2.2)
+    redis-actionpack (4.0.1)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.1.5)
+      activesupport (>= 3, < 5)
+      redis-store (~> 1.1.0)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.7)
+      redis (>= 2.2)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -281,6 +298,7 @@ DEPENDENCIES
   rails (= 4.2.1)
   rails_12factor
   rails_log_stdout!
+  redis-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   soda-ruby

--- a/app/controllers/case_histories_controller.rb
+++ b/app/controllers/case_histories_controller.rb
@@ -2,23 +2,41 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class CaseHistoriesController < ApplicationController
 
   def index
+    params[:filters] ||= {}
+    params[:page] ||= 1
+    @case_histories = if params[:filters].present?
+      live_index_results
+    else
+      cached_index_results
+    end
+  end
+
+  def show
+    @case_history = Rails.cache.fetch("case_histories_show_#{params[:id]}}") do
+      socrata = Socrata.new
+      case_number = params[:id].split('*').first
+      case_history_sakey = params[:id].split('*')[1]
+      opts = {
+        '$where': "case_number = '#{case_number}' and case_history_sakey='#{case_history_sakey}'"
+      }
+      socrata.client.get(socrata.case_history_dataset_id, opts).first
+    end
+  end
+
+  private
+
+  def live_index_results
     socrata = Socrata.new
     params[:filters] ||= {}
     opts = {'$order': 'date, case_number'}
     if params[:filters][:case]
       opts['$where'] = "case_number = '#{params[:filters][:case]}'"
     end
-    @case_histories = socrata.paginate(socrata.case_history_dataset_id, params[:page], opts)
+    socrata.paginate(socrata.case_history_dataset_id, params[:page], opts)
   end
 
-  def show
-    socrata = Socrata.new
-    case_number = params[:id].split('*').first
-    case_history_sakey = params[:id].split('*')[1]
-    opts = {
-      '$where': "case_number = '#{case_number}' and case_history_sakey='#{case_history_sakey}'"
-    }
-    @case_history = socrata.client.get(socrata.case_history_dataset_id, opts).first
+  def cached_index_results
+    Rails.cache.fetch("case_histories_index_page-#{params[:page]}}") { live_index_results }
   end
 
 end

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -2,13 +2,18 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class CasesController < ApplicationController
 
   def index
-    socrata = Socrata.new
-    @cases = socrata.paginate(socrata.case_dataset_id, params[:page], {'$order': 'entry_date, case_number'})
+    params[:page] ||= 1
+    @cases = Rails.cache.fetch("cases_index_page_#{params[:page]}") do
+      socrata = Socrata.new
+      socrata.paginate(socrata.case_dataset_id, params[:page], {'$order': 'entry_date, case_number'})
+    end
   end
 
   def show
-    socrata = Socrata.new
-    @case = socrata.client.get(socrata.case_dataset_id, {'$where': "case_number = '#{params[:id]}'"}).first
+    @case = Rails.cache.fetch("cases_show_#{params[:id]}}") do
+      socrata = Socrata.new
+      socrata.client.get(socrata.case_dataset_id, {'$where': "case_number = '#{params[:id]}'"}).first
+    end
   end
 
 end

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -2,38 +2,47 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class InspectionsController < ApplicationController
 
   def index
-    socrata = Socrata.new
     params[:filters] ||= {}
+    params[:page] ||= 1
+    @inspections = if params[:filters].present?
+      live_index_results
+    else
+      cached_index_results
+    end
+  end
+
+  def show
+    @inspection = Rails.cache.fetch("inspections_show_#{params[:id]}}") do
+      case_number = params[:id].split('*').first
+      entry_date = params[:id].split('*')[1]
+      inspection_date = params[:id].split('*')[2]
+
+      opts = {'$where' => "case_number = '#{case_number}'"}
+      if entry_date and entry_date = entry_date.to_i and entry_date > 0
+        opts['$where'] += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
+      end
+      if inspection_date and inspection_date = inspection_date.to_i and inspection_date > 0
+        opts['$where'] += " and inspection_date = '#{Time.at(inspection_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
+      end
+
+      socrata = Socrata.new
+      socrata.client.get(socrata.inspection_dataset_id, opts).first
+    end
+  end
+
+  private
+
+  def live_index_results
+    socrata = Socrata.new
     opts = {'$order': 'inspection_date, case_number'}
     if params[:filters][:case]
       opts['$where'] = "case_number = '#{params[:filters][:case]}'"
     end
-    @inspections = socrata.paginate(socrata.inspection_dataset_id, params[:page], opts)
+    socrata.paginate(socrata.inspection_dataset_id, params[:page], opts)
   end
 
-  def show
-    socrata = Socrata.new
-    case_number = params[:id].split('*').first
-    entry_date = params[:id].split('*')[1]
-    inspection_date = params[:id].split('*')[2]
-
-    # For some reason, ruby won't let you do something like this:
-    #  opts = {'$where': 'foo'}
-    #  opts['$where'] += ' and bar'
-    #
-    # It gives a whiny nil error when you try the += command.
-    # The workaround is to build a where clause string and add to
-    # opts at the end.
-    where = "case_number = '#{case_number}'"
-
-    if entry_date and entry_date = entry_date.to_i and entry_date > 0
-      where += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
-    end
-    if inspection_date and inspection_date = inspection_date.to_i and inspection_date > 0
-      where += " and inspection_date = '#{Time.at(inspection_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
-    end
-    opts = {'$where': where}
-    @inspection = socrata.client.get(socrata.inspection_dataset_id, opts).first
+  def cached_index_results
+    Rails.cache.fetch("inspections_index_page-#{params[:page]}}") { live_index_results }
   end
 
 end

--- a/app/controllers/violations_controller.rb
+++ b/app/controllers/violations_controller.rb
@@ -2,38 +2,47 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class ViolationsController < ApplicationController
 
   def index
-    socrata = Socrata.new
     params[:filters] ||= {}
+    params[:page] ||= 1
+    @violations = if params[:filters].present?
+      live_index_results
+    else
+      cached_index_results
+    end
+  end
+
+  def show
+    @violation = Rails.cache.fetch("violations_show_#{params[:id]}}") do
+      socrata = Socrata.new
+      case_number = params[:id].split('*').first
+      entry_date = params[:id].split('*')[1]
+      violation_code = params[:id].split('*')[2]
+
+      opts = {'$where' => "case_number = '#{case_number}'"}
+
+      if entry_date and entry_date = entry_date.to_i and entry_date > 0
+        opts['$where'] += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
+      end
+      if violation_code and violation_code != ''
+        opts['$where'] += " and violation_code = '#{violation_code}'"
+      end
+      socrata.client.get(socrata.violation_dataset_id, opts).first
+    end
+  end
+
+  private
+
+  def live_index_results
+    socrata = Socrata.new
     opts = {'$order': 'issued_date, case_number'}
     if params[:filters][:case]
       opts['$where'] = "case_number = '#{params[:filters][:case]}'"
     end
-    @violations = socrata.paginate(socrata.violation_dataset_id, params[:page], opts)
+    socrata.paginate(socrata.violation_dataset_id, params[:page], opts)
   end
 
-  def show
-    socrata = Socrata.new
-    case_number = params[:id].split('*').first
-    entry_date = params[:id].split('*')[1]
-    violation_code = params[:id].split('*')[2]
-
-    # For some reason, ruby won't let you do something like this:
-    #  opts = {'$where': 'foo'}
-    #  opts['$where'] += ' and bar'
-    #
-    # It gives a whiny nil error when you try the += command.
-    # The workaround is to build a where clause string and add to
-    # opts at the end.
-    where = "case_number = '#{case_number}'"
-
-    if entry_date and entry_date = entry_date.to_i and entry_date > 0
-      where += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
-    end
-    if violation_code and violation_code != ''
-      where += " and violation_code = '#{violation_code}'"
-    end
-    opts = {'$where': where}
-    @violation = socrata.client.get(socrata.violation_dataset_id, opts).first
+  def cached_index_results
+    Rails.cache.fetch("violations_index_page-#{params[:page]}}") { live_index_results }
   end
 
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,5 +22,8 @@ module LoeDashboard
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # redis
+    config.cache_store = :redis_store, 'redis://localhost:6379/0/cache', { expires_in: 20.minutes }
   end
 end


### PR DESCRIPTION
Use redis to cache `#show` actions and unfiltered `#index` actions.

You need to install redis on your development machine to make this work.  We'll probably have to refactor the redis config if/when we deploy to Heroku.

Here is some helpful documentation for Rails caching strategies: https://devcenter.heroku.com/articles/caching-strategies#low-level-caching