### PR TITLE
Setup models and seeding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,8 @@ group :development, :test do
   gem 'guard-livereload'
   gem 'guard-ctags-bundler'
   gem 'guard-puma'
+  gem 'factory_girl_rails', '~> 4.0'
+  gem 'faker'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,13 @@ GEM
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
+    faker (1.6.1)
+      i18n (~> 0.5)
     ffi (1.9.10)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -278,6 +285,8 @@ DEPENDENCIES
   bourbon
   byebug
   coffee-rails (~> 4.1.0)
+  factory_girl_rails (~> 4.0)
+  faker
   figaro (~> 1.1.0)
   font-awesome-rails (~> 4.3.0.0)
   guard

--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -2,17 +2,12 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class CasesController < ApplicationController
 
   def index
-    params[:page] ||= 1
-    @cases = Rails.cache.fetch("cases_index_page_#{params[:page]}") do
-      socrata = Socrata.new
-      socrata.paginate(socrata.case_dataset_id, params[:page], {'$order': 'entry_date, case_number'})
-    end
+    @cases = LoeCase.all.order('entry_date, case_number').page params[:page]
   end
 
   def show
     @case = Rails.cache.fetch("cases_show_#{params[:id]}}") do
-      socrata = Socrata.new
-      socrata.client.get(socrata.case_dataset_id, {'$where': "case_number = '#{params[:id]}'"}).first
+      LoeCase.find params[:id]
     end
   end
 

--- a/app/controllers/inspections_controller.rb
+++ b/app/controllers/inspections_controller.rb
@@ -2,47 +2,17 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class InspectionsController < ApplicationController
 
   def index
-    params[:filters] ||= {}
-    params[:page] ||= 1
-    @inspections = if params[:filters].present?
-      live_index_results
+    @inspections = if params[:filters] and params[:filters][:case]
+      Inspection.for_case(params[:filters][:case]).page params[:page]
     else
-      cached_index_results
+      Inspection.all.order('entry_date, case_number').page params[:page]
     end
   end
 
   def show
     @inspection = Rails.cache.fetch("inspections_show_#{params[:id]}}") do
-      case_number = params[:id].split('*').first
-      entry_date = params[:id].split('*')[1]
-      inspection_date = params[:id].split('*')[2]
-
-      opts = {'$where' => "case_number = '#{case_number}'"}
-      if entry_date and entry_date = entry_date.to_i and entry_date > 0
-        opts['$where'] += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
-      end
-      if inspection_date and inspection_date = inspection_date.to_i and inspection_date > 0
-        opts['$where'] += " and inspection_date = '#{Time.at(inspection_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
-      end
-
-      socrata = Socrata.new
-      socrata.client.get(socrata.inspection_dataset_id, opts).first
+      Inspection.find params[:id]
     end
-  end
-
-  private
-
-  def live_index_results
-    socrata = Socrata.new
-    opts = {'$order': 'inspection_date, case_number'}
-    if params[:filters][:case]
-      opts['$where'] = "case_number = '#{params[:filters][:case]}'"
-    end
-    socrata.paginate(socrata.inspection_dataset_id, params[:page], opts)
-  end
-
-  def cached_index_results
-    Rails.cache.fetch("inspections_index_page-#{params[:page]}}") { live_index_results }
   end
 
 end

--- a/app/controllers/violations_controller.rb
+++ b/app/controllers/violations_controller.rb
@@ -2,47 +2,18 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class ViolationsController < ApplicationController
 
   def index
-    params[:filters] ||= {}
-    params[:page] ||= 1
-    @violations = if params[:filters].present?
-      live_index_results
+    @violations = if params[:filters] and params[:filters][:case]
+      Violation.for_case(params[:filters][:case]).page params[:page]
     else
-      cached_index_results
+      Violation.all.order('entry_date, case_number').page params[:page]
     end
   end
 
   def show
     @violation = Rails.cache.fetch("violations_show_#{params[:id]}}") do
-      socrata = Socrata.new
-      case_number = params[:id].split('*').first
-      entry_date = params[:id].split('*')[1]
-      violation_code = params[:id].split('*')[2]
-
-      opts = {'$where' => "case_number = '#{case_number}'"}
-
-      if entry_date and entry_date = entry_date.to_i and entry_date > 0
-        opts['$where'] += " and entry_date = '#{Time.at(entry_date).strftime("%Y-%m-%dT%H:%M:%S")}'"
-      end
-      if violation_code and violation_code != ''
-        opts['$where'] += " and violation_code = '#{violation_code}'"
-      end
-      socrata.client.get(socrata.violation_dataset_id, opts).first
+      Violation.find params[:id]
     end
   end
 
-  private
-
-  def live_index_results
-    socrata = Socrata.new
-    opts = {'$order': 'issued_date, case_number'}
-    if params[:filters][:case]
-      opts['$where'] = "case_number = '#{params[:filters][:case]}'"
-    end
-    socrata.paginate(socrata.violation_dataset_id, params[:page], opts)
-  end
-
-  def cached_index_results
-    Rails.cache.fetch("violations_index_page-#{params[:page]}}") { live_index_results }
-  end
 
 end

--- a/app/helpers/inspections_helper.rb
+++ b/app/helpers/inspections_helper.rb
@@ -1,8 +1,8 @@
 module InspectionsHelper
 
   def unique_inspection_id(inspection)
-    entry_date = Time.parse inspection.entry_date
-    inspection_date = Time.parse inspection.inspection_date
+    entry_date = inspection.entry_date
+    inspection_date = inspection.inspection_date
     "#{inspection.case_number}*#{entry_date ? entry_date.to_i : nil}*#{inspection_date ? inspection_date.to_i : nil}"
   end
 end

--- a/app/helpers/violations_helper.rb
+++ b/app/helpers/violations_helper.rb
@@ -1,7 +1,7 @@
 module ViolationsHelper
 
   def unique_violation_id(violation)
-    entry_date = Time.parse violation.entry_date
+    entry_date = violation.entry_date
     "#{violation.case_number}*#{entry_date ? entry_date.to_i : nil}*#{violation.violation_code}"
   end
 

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -35,7 +35,7 @@ class Inspection < ActiveRecord::Base
         case col.to_s
         when "case_sakey", "case_number", "inspection_sakey"
           self[col.to_sym] = socrata_result[key].strip.to_i
-          if key == "case_number"
+          if col == "case_number"
             self.loe_case_id = LoeCase.where('case_number = ?',self[col.to_sym]).limit(1).select('id').first.try(:id)
 
           end

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -1,6 +1,24 @@
 require File.expand_path(Rails.root)+'/lib/socrata'
 class Inspection < ActiveRecord::Base
 
+  SOCRATA_ATTRIBUTE_REMAPPING = {
+    "casenumber" => "case_number",
+    "casesakey" => "case_sakey",
+    "entrydate" => "entry_date",
+    "inspectiondate" => "inspection_date",
+    "inspectionnotes" => "inspection_notes",
+    "inspectionsakey" => "inspection_sakey",
+    "inspectiontype" => "inspection_type",
+    "inspectiontypedesc" => "inspection_type_desc",
+    "lastupdate" => "last_update",
+    "openandvacant" => "open_and_vacant",
+    "stapt" => "st_apt",
+    "stname" => "st_name",
+    "stnumber" => "st_number",
+    "sttype" => "st_type"
+  }
+
+
   belongs_to :loe_case
 
   scope :for_case, -> (loe_case_id) { where(loe_case_id: loe_case_id).order('case_sakey') }
@@ -11,27 +29,28 @@ class Inspection < ActiveRecord::Base
 
   def assign_from_socrata(socrata_result)
     socrata_result.keys.each do |key|
-      raise "undefined attribute: #{key}\n#{socrata_result.to_json}" unless self.class.column_names.include?(key)
+      col = self.class::SOCRATA_ATTRIBUTE_REMAPPING[key] || key
+      raise "undefined attribute: #{key}\n#{socrata_result.to_json}" unless self.class.column_names.include?(col)
       unless socrata_result[key].strip == "NULL"
-        case key
+        case col.to_s
         when "case_sakey", "case_number", "inspection_sakey"
-          self[key.to_sym] = socrata_result[key].strip.to_i
+          self[col.to_sym] = socrata_result[key].strip.to_i
           if key == "case_number"
-            self.loe_case_id = LoeCase.where('case_number = ?',self[key.to_sym]).limit(1).select('id').first.try(:id)
+            self.loe_case_id = LoeCase.where('case_number = ?',self[col.to_sym]).limit(1).select('id').first.try(:id)
 
           end
         when "inspection_date", "entry_date", "last_update"
           begin
             if socrata_result[key].strip.match(/^\d+\/\d+\/\d+ \d+:\d+$/)
-              self[key.to_sym] = Time.strptime(socrata_result[key].strip,"%m/%d/%Y %H:%M")
+              self[col.to_sym] = Time.strptime(socrata_result[key].strip,"%m/%d/%Y %H:%M")
             else
-              self[key.to_sym] = Time.parse(socrata_result[key].strip)
+              self[col.to_sym] = Time.parse(socrata_result[key].strip)
             end
           rescue ArgumentError => e
             puts "val: #{socrata_result[key].strip}"
             raise e
           end
-        else self[key.to_sym] = socrata_result[key].strip
+        else self[col.to_sym] = socrata_result[key].strip
         end
       end
     end

--- a/app/models/inspection.rb
+++ b/app/models/inspection.rb
@@ -1,0 +1,39 @@
+require File.expand_path(Rails.root)+'/lib/socrata'
+class Inspection < ActiveRecord::Base
+
+  belongs_to :loe_case
+
+  scope :for_case, -> (loe_case_id) { where(loe_case_id: loe_case_id).order('case_sakey') }
+
+  def self.seed
+    Socrata.seed self, Socrata.inspection_dataset_id
+  end
+
+  def assign_from_socrata(socrata_result)
+    socrata_result.keys.each do |key|
+      raise "undefined attribute: #{key}\n#{socrata_result.to_json}" unless self.class.column_names.include?(key)
+      unless socrata_result[key].strip == "NULL"
+        case key
+        when "case_sakey", "case_number", "inspection_sakey"
+          self[key.to_sym] = socrata_result[key].strip.to_i
+          if key == "case_number"
+            self.loe_case_id = LoeCase.where('case_number = ?',self[key.to_sym]).limit(1).select('id').first.try(:id)
+
+          end
+        when "inspection_date", "entry_date", "last_update"
+          begin
+            if socrata_result[key].strip.match(/^\d+\/\d+\/\d+ \d+:\d+$/)
+              self[key.to_sym] = Time.strptime(socrata_result[key].strip,"%m/%d/%Y %H:%M")
+            else
+              self[key.to_sym] = Time.parse(socrata_result[key].strip)
+            end
+          rescue ArgumentError => e
+            puts "val: #{socrata_result[key].strip}"
+            raise e
+          end
+        else self[key.to_sym] = socrata_result[key].strip
+        end
+      end
+    end
+  end
+end

--- a/app/models/loe_case.rb
+++ b/app/models/loe_case.rb
@@ -1,6 +1,39 @@
 require File.expand_path(Rails.root)+'/lib/socrata'
 class LoeCase < ActiveRecord::Base
 
+  SOCRATA_ATTRIBUTE_REMAPPING = {
+    "adlot" => "ad_lot",
+    "adsakey" => "ad_sakey",
+    "annexdate" => "annex_date",
+    "assignedinspcode" => "assigned_inspector_code",
+    "casenotes" => "case_notes",
+    "casenumber" => "case_number",
+    "casestatus" => "case_status",
+    "casetype" => "case_type",
+    "censustract" => "census_tract",
+    "closedate" => "close_date",
+    "closereason" => "close_reason",
+    "duedate" => "due_date",
+    "entrydate" => "entry_date",
+    "fulladdress" => "full_address",
+    "lastupdate" => "last_update",
+    "ownermailcity" => "owner_mailcity",
+    "ownermailstate" => "owner_mailstate",
+    "ownermailaddr" => "owner_mailaddr",
+    "ownermailaddr2" => "owner_mailaddr2",
+    "ownermailzip" => "owner_mailzip",
+    "ownername" => "owner_name",
+    "ownername2" => "owner_name2",
+    "rentalstatus" => "rental_status",
+    "stapt" => "st_apt",
+    "stname" => "st_name",
+    "stnumber" => "st_number",
+    "sttype" => "st_type",
+    "usecode" => "use_code",
+    "xcoord" => "x_coord",
+    "ycoord" => "y_coord"
+  }
+
   has_many :inspections, -> { order(:case_sakey) }
   has_many :violations, -> { order(:case_sakey) }
 
@@ -10,22 +43,25 @@ class LoeCase < ActiveRecord::Base
 
   def assign_from_socrata(socrata_result)
     socrata_result.keys.each do |key|
-      raise "undefined attribute: #{key}" unless self.class.column_names.include?(key)
-      case key
+      col = self.class::SOCRATA_ATTRIBUTE_REMAPPING[key] || key
+      raise "undefined attribute: #{key}" unless self.class.column_names.include?(col)
+      case col.to_s
       when "ad_sakey", "case_number"
-        self[key.to_sym] = socrata_result[key].strip.to_i
+        self[col.to_sym] = socrata_result[key].strip.to_i
       when "annex_date"
         val = socrata_result[key].strip.split(",")[0].strip
         if val.length==4
           val += "/01/01"
         end
-        self[key.to_sym] = Date.parse val
-        if self[key.to_sym] > Date.today
-          self[key.to_sym] = self[key.to_sym].to_time.advance(years: -100).to_date
+        self[col.to_sym] = Date.parse val
+        if self[col.to_sym] > Date.today
+          self[col.to_sym] = self[col.to_sym].to_time.advance(years: -100).to_date
         end
       when "close_date", "due_date", "entry_date", "last_update"
-        self[key.to_sym] = Time.parse(socrata_result[key].strip)
-      else self[key.to_sym] = socrata_result[key].strip
+        self[col.to_sym] = Time.parse(socrata_result[key].strip)
+      when "x_coord", "y_coord"
+        self[col.to_sym] = socrata_result[key].strip.to_f
+      else self[col.to_sym] = socrata_result[key].strip
       end
     end
   end

--- a/app/models/loe_case.rb
+++ b/app/models/loe_case.rb
@@ -2,6 +2,7 @@ require File.expand_path(Rails.root)+'/lib/socrata'
 class LoeCase < ActiveRecord::Base
 
   has_many :inspections, -> { order(:case_sakey) }
+  has_many :violations, -> { order(:case_sakey) }
 
   def self.seed
     Socrata.seed self, Socrata.case_dataset_id

--- a/app/models/loe_case.rb
+++ b/app/models/loe_case.rb
@@ -1,6 +1,8 @@
 require File.expand_path(Rails.root)+'/lib/socrata'
 class LoeCase < ActiveRecord::Base
 
+  has_many :inspections, -> { order(:case_sakey) }
+
   def self.seed
     Socrata.seed self, Socrata.case_dataset_id
   end

--- a/app/models/loe_case.rb
+++ b/app/models/loe_case.rb
@@ -1,0 +1,30 @@
+require File.expand_path(Rails.root)+'/lib/socrata'
+class LoeCase < ActiveRecord::Base
+
+  def self.seed
+    Socrata.seed self, Socrata.case_dataset_id
+  end
+
+  def assign_from_socrata(socrata_result)
+    socrata_result.keys.each do |key|
+      raise "undefined attribute: #{key}" unless self.class.column_names.include?(key)
+      case key
+      when "ad_sakey", "case_number"
+        self[key.to_sym] = socrata_result[key].strip.to_i
+      when "annex_date"
+        val = socrata_result[key].strip.split(",")[0].strip
+        if val.length==4
+          val += "/01/01"
+        end
+        self[key.to_sym] = Date.parse val
+        if self[key.to_sym] > Date.today
+          self[key.to_sym] = self[key.to_sym].to_time.advance(years: -100).to_date
+        end
+      when "close_date", "due_date", "entry_date", "last_update"
+        self[key.to_sym] = Time.parse(socrata_result[key].strip)
+      else self[key.to_sym] = socrata_result[key].strip
+      end
+    end
+  end
+
+end

--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -1,6 +1,33 @@
 require File.expand_path(Rails.root)+'/lib/socrata'
 class Violation < ActiveRecord::Base
 
+  SOCRATA_ATTRIBUTE_REMAPPING = {
+    "casenumber" => "case_number",
+    "casesakey" => "case_sakey",
+    "cleardate" => "clear_date",
+    "clearedby" => "cleared_by",
+    "entrydate" => "entry_date",
+    "issuedby" => "issued_by",
+    "issueddate" => "issued_date",
+    "lastupdate" => "last_update",
+    "majorviolation" => "major_violation",
+    "numberofitems" => "number_of_items",
+    "reissuedate" => "reissue_date",
+    "reissuedby" => "reissued_by",
+    "responsibleparty" => "responsible_party",
+    "stapt" => "st_apt",
+    "stname" => "st_name",
+    "stnumber" => "st_number",
+    "sttype" => "st_type",
+    "violationcleared" => "violation_cleared",
+    "violationcode" => "violation_code",
+    "violationdescription" => "violation_description",
+    "violationissued" => "violation_issued",
+    "violationreissued" => "violation_reissued",
+    "violationsakey" => "violation_sakey"
+  }
+
+
   belongs_to :loe_case
 
   scope :for_case, -> (loe_case_id) { where(loe_case_id: loe_case_id).order('case_sakey') }
@@ -11,26 +38,27 @@ class Violation < ActiveRecord::Base
 
   def assign_from_socrata(socrata_result)
     socrata_result.keys.each do |key|
-      raise "undefined attribute: #{key}\n#{socrata_result.to_json}" unless self.class.column_names.include?(key)
+      col = self.class::SOCRATA_ATTRIBUTE_REMAPPING[key] || key
+      raise "undefined attribute: #{key}\n#{socrata_result.to_json}" unless self.class.column_names.include?(col)
       unless socrata_result[key].strip == "NULL"
-        case key
+        case col.to_s
         when "case_sakey", "case_number", "violation_sakey", "number_of_items"
-          self[key.to_sym] = socrata_result[key].strip.to_i
+          self[col.to_sym] = socrata_result[key].strip.to_i
           if key == "case_number"
-            self.loe_case_id = LoeCase.where('case_number = ?',self[key.to_sym]).limit(1).select('id').first.try(:id)
+            self.loe_case_id = LoeCase.where('case_number = ?',self[col.to_sym]).limit(1).select('id').first.try(:id)
           end
         when "clear_date", "entry_date", "last_update", "issued_date", "reissue_date"
           begin
             if socrata_result[key].strip.match(/^\d+\/\d+\/\d+ \d+:\d+$/)
-              self[key.to_sym] = Time.strptime(socrata_result[key].strip,"%m/%d/%Y %H:%M")
+              self[col.to_sym] = Time.strptime(socrata_result[key].strip,"%m/%d/%Y %H:%M")
             else
-              self[key.to_sym] = Time.parse(socrata_result[key].strip)
+              self[col.to_sym] = Time.parse(socrata_result[key].strip)
             end
           rescue ArgumentError => e
             puts "val: #{socrata_result[key].strip}"
             raise e
           end
-        else self[key.to_sym] = socrata_result[key].strip
+        else self[col.to_sym] = socrata_result[key].strip
         end
       end
     end

--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -44,7 +44,7 @@ class Violation < ActiveRecord::Base
         case col.to_s
         when "case_sakey", "case_number", "violation_sakey", "number_of_items"
           self[col.to_sym] = socrata_result[key].strip.to_i
-          if key == "case_number"
+          if col == "case_number"
             self.loe_case_id = LoeCase.where('case_number = ?',self[col.to_sym]).limit(1).select('id').first.try(:id)
           end
         when "clear_date", "entry_date", "last_update", "issued_date", "reissue_date"

--- a/app/models/violation.rb
+++ b/app/models/violation.rb
@@ -1,0 +1,39 @@
+require File.expand_path(Rails.root)+'/lib/socrata'
+class Violation < ActiveRecord::Base
+
+  belongs_to :loe_case
+
+  scope :for_case, -> (loe_case_id) { where(loe_case_id: loe_case_id).order('case_sakey') }
+
+  def self.seed
+    Socrata.seed self, Socrata.violation_dataset_id
+  end
+
+  def assign_from_socrata(socrata_result)
+    socrata_result.keys.each do |key|
+      raise "undefined attribute: #{key}\n#{socrata_result.to_json}" unless self.class.column_names.include?(key)
+      unless socrata_result[key].strip == "NULL"
+        case key
+        when "case_sakey", "case_number", "violation_sakey", "number_of_items"
+          self[key.to_sym] = socrata_result[key].strip.to_i
+          if key == "case_number"
+            self.loe_case_id = LoeCase.where('case_number = ?',self[key.to_sym]).limit(1).select('id').first.try(:id)
+          end
+        when "clear_date", "entry_date", "last_update", "issued_date", "reissue_date"
+          begin
+            if socrata_result[key].strip.match(/^\d+\/\d+\/\d+ \d+:\d+$/)
+              self[key.to_sym] = Time.strptime(socrata_result[key].strip,"%m/%d/%Y %H:%M")
+            else
+              self[key.to_sym] = Time.parse(socrata_result[key].strip)
+            end
+          rescue ArgumentError => e
+            puts "val: #{socrata_result[key].strip}"
+            raise e
+          end
+        else self[key.to_sym] = socrata_result[key].strip
+        end
+      end
+    end
+  end
+
+end

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -6,11 +6,11 @@
     <th>Case Notes</th>
   </thead>
   <tbody>
-    <% @cases.compact.each do |item| %>
-      <tr data-item-number="<%= item.case_number -%>">
-        <td><%= link_to item.case_number, case_path(item.case_number) %></td>
-        <td><%= Date.parse(item.entry_date) %></td>
-        <td><%= item.case_notes %></td>
+    <% @cases.each do |loe_case| %>
+      <tr data-id="<%= loe_case.id -%>">
+        <td><%= link_to loe_case.case_number, case_path(loe_case) %></td>
+        <td><%= loe_case.entry_date.try :localtime %></td>
+        <td><%= loe_case.case_notes %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,5 +1,5 @@
 <h1>Case Detail</h1>
-<pre><%= @case.to_yaml %></pre>
+<pre><%= @case.attributes.to_yaml %></pre>
 <%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Case Violations', violations_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Case Histories', case_histories_path(filters: {'case': @case.case_number}) %><br />

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Case Detail</h1>
 <pre><%= @case.attributes.to_yaml %></pre>
 <%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.id}) %><br />
-<%= link_to 'Case Violations', violations_path(filters: {'case': @case.case_number}) %><br />
+<%= link_to 'Case Violations', violations_path(filters: {'case': @case.id}) %><br />
 <%= link_to 'Case Histories', case_histories_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Browse Cases', cases_path %>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Case Detail</h1>
 <pre><%= @case.attributes.to_yaml %></pre>
-<%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.case_number}) %><br />
+<%= link_to 'Case Inspections', inspections_path(filters: {'case': @case.id}) %><br />
 <%= link_to 'Case Violations', violations_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Case Histories', case_histories_path(filters: {'case': @case.case_number}) %><br />
 <%= link_to 'Browse Cases', cases_path %>

--- a/app/views/inspections/index.html.erb
+++ b/app/views/inspections/index.html.erb
@@ -6,10 +6,10 @@
     <th>Description</th>
   </thead>
   <tbody>
-    <% @inspections.compact.each do |inspection| %>
-      <tr data-unique-id="<%= unique_inspection_id(inspection) -%>">
-        <td><%= link_to inspection.case_number, inspection_path(unique_inspection_id(inspection)) %></td>
-        <td><%= Date.parse(inspection.inspection_date) %></td>
+    <% @inspections.each do |inspection| %>
+      <tr data-id="<%= inspection.id -%>">
+        <td><%= link_to inspection.case_number, inspection_path(inspection) %></td>
+        <td><%= inspection.inspection_date %></td>
         <td><%= inspection.inspection_type_desc %></td>
       </tr>
     <% end %>

--- a/app/views/inspections/show.html.erb
+++ b/app/views/inspections/show.html.erb
@@ -1,4 +1,4 @@
 <h1>Inspection Detail</h1>
 <pre><%= @inspection.to_yaml %></pre>
-<%= link_to 'View Case', case_path(@inspection.case_number) %><br />
+<%= link_to 'View Case', case_path(@inspection.loe_case_id) %><br />
 <%= link_to 'Browse Inspections', inspections_path %>

--- a/app/views/violations/index.html.erb
+++ b/app/views/violations/index.html.erb
@@ -6,10 +6,10 @@
     <th>Description</th>
   </thead>
   <tbody>
-    <% @violations.compact.each do |violation| %>
-      <tr data-unique-id="<%= unique_violation_id(violation) -%>">
-        <td><%= link_to violation.case_number, violation_path(unique_violation_id(violation)) %></td>
-        <td><%= Date.parse(violation.issued_date) %></td>
+    <% @violations.each do |violation| %>
+      <tr data-id="<%= violation.id -%>">
+        <td><%= link_to violation.case_number, violation_path(violation) %></td>
+        <td><%= violation.issued_date %></td>
         <td><%= violation.violation_description %></td>
       </tr>
     <% end %>

--- a/app/views/violations/show.html.erb
+++ b/app/views/violations/show.html.erb
@@ -1,4 +1,4 @@
 <h1>Violation Detail</h1>
 <pre><%= @violation.to_yaml %></pre>
-<%= link_to 'View Case', case_path(@violation.case_number) %><br />
+<%= link_to 'View Case', case_path(@violation.loe_case_id) %><br />
 <%= link_to 'Browse Violations', violations_path %>

--- a/db/migrate/20151220155713_create_loe_cases.rb
+++ b/db/migrate/20151220155713_create_loe_cases.rb
@@ -1,0 +1,38 @@
+class CreateLoeCases < ActiveRecord::Migration
+  def change
+    create_table :loe_cases do |t|
+      t.string :ad_lot
+      t.integer :ad_sakey
+      t.string :ad_st_apt
+      t.string :ad_st_name
+      t.string :ad_st_num
+      t.string :ad_st_type
+      t.date :annex_date
+      t.string :assigned_inspector_code
+      t.string :assignment
+      t.text :case_notes
+      t.integer :case_number
+      t.string :case_status
+      t.string :case_type
+      t.string :census_tract
+      t.datetime :close_date
+      t.string :close_reason
+      t.datetime :due_date
+      t.datetime :entry_date
+      t.datetime :last_update
+      t.string :origin
+      t.string :owner_mailaddr
+      t.string :owner_mailaddr2
+      t.string :owner_mailcity
+      t.string :owner_mailstate
+      t.string :owner_mailzip
+      t.string :owner_name
+      t.string :owner_name2
+      t.string :rental_status
+      t.string :use_code
+      t.string :zoning
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20151223025229_create_inspections.rb
+++ b/db/migrate/20151223025229_create_inspections.rb
@@ -1,0 +1,26 @@
+class CreateInspections < ActiveRecord::Migration
+  def change
+    create_table :inspections do |t|
+      t.integer :loe_case_id
+      t.string :ad_st_apt
+      t.string :ad_st_name
+      t.string :ad_st_num
+      t.string :ad_st_type
+      t.integer :case_number
+      t.integer :case_sakey
+      t.string :compliant
+      t.datetime :entry_date
+      t.datetime :inspection_date
+      t.text :inspection_notes
+      t.integer :inspection_sakey
+      t.string :inspection_type
+      t.string :inspection_type_desc
+      t.string :inspector
+      t.datetime :last_update
+      t.string :open_and_vacant
+      t.string :unfounded
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160104015640_create_violations.rb
+++ b/db/migrate/20160104015640_create_violations.rb
@@ -1,0 +1,33 @@
+class CreateViolations < ActiveRecord::Migration
+  def change
+    create_table :violations do |t|
+      t.integer :loe_case_id
+      t.string :ad_st_name
+      t.string :ad_st_num
+      t.string :ad_st_type
+      t.integer :case_number
+      t.integer :case_sakey
+      t.datetime :clear_date
+      t.string :cleared_by
+      t.datetime :entry_date
+      t.string :issued_by
+      t.datetime :issued_date
+      t.datetime :last_update
+      t.integer :number_of_items
+      t.datetime :reissue_date
+      t.string :reissued_by
+      t.string :violation_cleared
+      t.string :violation_code
+      t.string :violation_description
+      t.string :violation_issued
+      t.string :violation_reissued
+      t.integer :violation_sakey
+      t.string :major_violation
+      t.string :responsible_party
+      t.text :comments
+      t.string :ad_st_apt
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20160109012741_add_new_columns_to_loe_cases.rb
+++ b/db/migrate/20160109012741_add_new_columns_to_loe_cases.rb
@@ -1,0 +1,17 @@
+class AddNewColumnsToLoeCases < ActiveRecord::Migration
+  def change
+    change_table :loe_cases do |t|
+      t.string :city
+      t.text :full_address
+      t.string :state
+      t.string :stpfxdir
+      t.string :stsfxdir
+      t.string :st_apt
+      t.string :st_name
+      t.string :st_number
+      t.string :st_type
+      t.float :x_coord
+      t.float :y_coord
+    end
+  end
+end

--- a/db/migrate/20160110144459_add_new_columns_to_inspections.rb
+++ b/db/migrate/20160110144459_add_new_columns_to_inspections.rb
@@ -1,0 +1,12 @@
+class AddNewColumnsToInspections < ActiveRecord::Migration
+  def change
+    change_table :inspections do |t|
+      t.string :stpfxdir
+      t.string :stsfxdir
+      t.string :st_apt
+      t.string :st_name
+      t.string :st_number
+      t.string :st_type
+    end
+  end
+end

--- a/db/migrate/20160110172343_add_new_columns_to_violations.rb
+++ b/db/migrate/20160110172343_add_new_columns_to_violations.rb
@@ -1,0 +1,12 @@
+class AddNewColumnsToViolations < ActiveRecord::Migration
+  def change
+    change_table :violations do |t|
+      t.string :stpfxdir
+      t.string :stsfxdir
+      t.string :st_apt
+      t.string :st_name
+      t.string :st_number
+      t.string :st_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160110144459) do
+ActiveRecord::Schema.define(version: 20160110172343) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -119,6 +119,12 @@ ActiveRecord::Schema.define(version: 20160110144459) do
     t.string   "ad_st_apt"
     t.datetime "created_at",            null: false
     t.datetime "updated_at",            null: false
+    t.string   "stpfxdir"
+    t.string   "stsfxdir"
+    t.string   "st_apt"
+    t.string   "st_name"
+    t.string   "st_number"
+    t.string   "st_type"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160104015640) do
+ActiveRecord::Schema.define(version: 20160109012741) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,17 @@ ActiveRecord::Schema.define(version: 20160104015640) do
     t.string   "zoning"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+    t.string   "city"
+    t.text     "full_address"
+    t.string   "state"
+    t.string   "stpfxdir"
+    t.string   "stsfxdir"
+    t.string   "st_apt"
+    t.string   "st_name"
+    t.string   "st_number"
+    t.string   "st_type"
+    t.float    "x_coord"
+    t.float    "y_coord"
   end
 
   create_table "violations", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151223025229) do
+ActiveRecord::Schema.define(version: 20160104015640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,36 @@ ActiveRecord::Schema.define(version: 20151223025229) do
     t.string   "zoning"
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
+  end
+
+  create_table "violations", force: :cascade do |t|
+    t.integer  "loe_case_id"
+    t.string   "ad_st_name"
+    t.string   "ad_st_num"
+    t.string   "ad_st_type"
+    t.integer  "case_number"
+    t.integer  "case_sakey"
+    t.datetime "clear_date"
+    t.string   "cleared_by"
+    t.datetime "entry_date"
+    t.string   "issued_by"
+    t.datetime "issued_date"
+    t.datetime "last_update"
+    t.integer  "number_of_items"
+    t.datetime "reissue_date"
+    t.string   "reissued_by"
+    t.string   "violation_cleared"
+    t.string   "violation_code"
+    t.string   "violation_description"
+    t.string   "violation_issued"
+    t.string   "violation_reissued"
+    t.integer  "violation_sakey"
+    t.string   "major_violation"
+    t.string   "responsible_party"
+    t.text     "comments"
+    t.string   "ad_st_apt"
+    t.datetime "created_at",            null: false
+    t.datetime "updated_at",            null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,54 @@
+# encoding: UTF-8
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20151220155713) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "loe_cases", force: :cascade do |t|
+    t.string   "ad_lot"
+    t.integer  "ad_sakey"
+    t.string   "ad_st_apt"
+    t.string   "ad_st_name"
+    t.string   "ad_st_num"
+    t.string   "ad_st_type"
+    t.date     "annex_date"
+    t.string   "assigned_inspector_code"
+    t.string   "assignment"
+    t.text     "case_notes"
+    t.integer  "case_number"
+    t.string   "case_status"
+    t.string   "case_type"
+    t.string   "census_tract"
+    t.datetime "close_date"
+    t.string   "close_reason"
+    t.datetime "due_date"
+    t.datetime "entry_date"
+    t.datetime "last_update"
+    t.string   "origin"
+    t.string   "owner_mailaddr"
+    t.string   "owner_mailaddr2"
+    t.string   "owner_mailcity"
+    t.string   "owner_mailstate"
+    t.string   "owner_mailzip"
+    t.string   "owner_name"
+    t.string   "owner_name2"
+    t.string   "rental_status"
+    t.string   "use_code"
+    t.string   "zoning"
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,33 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151220155713) do
+ActiveRecord::Schema.define(version: 20151223025229) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "inspections", force: :cascade do |t|
+    t.integer  "loe_case_id"
+    t.string   "ad_st_apt"
+    t.string   "ad_st_name"
+    t.string   "ad_st_num"
+    t.string   "ad_st_type"
+    t.integer  "case_number"
+    t.integer  "case_sakey"
+    t.string   "compliant"
+    t.datetime "entry_date"
+    t.datetime "inspection_date"
+    t.text     "inspection_notes"
+    t.integer  "inspection_sakey"
+    t.string   "inspection_type"
+    t.string   "inspection_type_desc"
+    t.string   "inspector"
+    t.datetime "last_update"
+    t.string   "open_and_vacant"
+    t.string   "unfounded"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
 
   create_table "loe_cases", force: :cascade do |t|
     t.string   "ad_lot"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160109012741) do
+ActiveRecord::Schema.define(version: 20160110144459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,12 @@ ActiveRecord::Schema.define(version: 20160109012741) do
     t.string   "unfounded"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
+    t.string   "stpfxdir"
+    t.string   "stsfxdir"
+    t.string   "st_apt"
+    t.string   "st_name"
+    t.string   "st_number"
+    t.string   "st_type"
   end
 
   create_table "loe_cases", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,8 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
-[LoeCase].each do |klass|
+
+[LoeCase, Inspection].each do |klass|
   puts "\nseeding #{klass}..."
   klass.seed
   print "done"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,7 +6,7 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-[LoeCase, Inspection].each do |klass|
+[LoeCase, Inspection, Violation].each do |klass|
   puts "\nseeding #{klass}..."
   klass.seed
   print "done"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,12 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+[LoeCase].each do |klass|
+  puts "\nseeding #{klass}..."
+  klass.seed
+  print "done"
+end
+
+puts "\nclearing cache..."
+Rails.cache.clear
+print "done"

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -28,7 +28,7 @@ class CasesControllerTest < ActionController::TestCase
     assert assigns['case'].kind_of?(LoeCase)
     assert_equal expected.case_number, assigns['case'].case_number
     assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].id})}']", text: 'Case Inspections'
-    assert_select "a[href='#{violations_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Violations'
+    assert_select "a[href='#{violations_path(filters: {'case': assigns['case'].id})}']", text: 'Case Violations'
     assert_select "a[href='#{case_histories_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Histories'
     assert_select "a[href='#{cases_path}']"
   end

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -3,26 +3,29 @@ require 'test_helper'
 class CasesControllerTest < ActionController::TestCase
 
   test "should get index" do
+    expected_count = Kaminari.config.default_per_page
+    expected_count.times do
+      create :loe_case
+    end
     get :index
     assert_response :success
-    assert assigns['cases'].kind_of?(Array)
+    assert assigns['cases'].kind_of?(LoeCase::ActiveRecord_Relation)
     assert_not_equal 0, assigns['cases'].size
+    assert_equal expected_count, assigns['cases'].size
     assert_select "table tbody" do
       assigns['cases'].each do |item|
-        assert_select "tr[data-item-number='#{item.case_number}']" do
-          assert_select "td a[href='#{case_path(item.case_number)}']", text: item.case_number
+        assert_select "tr[data-id='#{item.id}']" do
+          assert_select "td a[href='#{case_path(item)}']", text: item.case_number.to_s
         end
       end
     end
   end
 
   test "should get show" do
-    require File.expand_path(Rails.root)+'/lib/socrata'
-    socrata = Socrata.new
-    expected = socrata.client.get(socrata.case_dataset_id,{'$limit': 1}).first
-    get :show, {id: expected.case_number}
+    expected = create :loe_case
+    get :show, {id: expected.id}
     assert_response :success
-    assert assigns['case'].kind_of?(Hashie::Mash)
+    assert assigns['case'].kind_of?(LoeCase)
     assert_equal expected.case_number, assigns['case'].case_number
     assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Inspections'
     assert_select "a[href='#{violations_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Violations'

--- a/test/controllers/cases_controller_test.rb
+++ b/test/controllers/cases_controller_test.rb
@@ -27,7 +27,7 @@ class CasesControllerTest < ActionController::TestCase
     assert_response :success
     assert assigns['case'].kind_of?(LoeCase)
     assert_equal expected.case_number, assigns['case'].case_number
-    assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Inspections'
+    assert_select "a[href='#{inspections_path(filters: {'case': assigns['case'].id})}']", text: 'Case Inspections'
     assert_select "a[href='#{violations_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Violations'
     assert_select "a[href='#{case_histories_path(filters: {'case': assigns['case'].case_number})}']", text: 'Case Histories'
     assert_select "a[href='#{cases_path}']"

--- a/test/factories/inspections.rb
+++ b/test/factories/inspections.rb
@@ -1,0 +1,25 @@
+FactoryGirl.define do
+  factory :inspection do
+    loe_case
+    ad_st_apt                 {Faker::Lorem.words.join(' ')}
+    ad_st_name                {Faker::Lorem.words.join(' ')}
+    ad_st_num                 {Faker::Lorem.words.join(' ')}
+    ad_st_type                {Faker::Lorem.words.join(' ')}
+    case_sakey                {Faker::Number.between(1, 10000)}
+    compliant                 {Faker::Lorem.words.join(' ')}
+    entry_date                {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    inspection_date           {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    inspection_notes          {Faker::Lorem.paragraphs.join("\n\n")}
+    inspection_sakey          {Faker::Number.between(1, 10000)}
+    inspection_type           {Faker::Lorem.words.join(' ')}
+    inspection_type_desc      {Faker::Lorem.words.join(' ')}
+    inspector                 {Faker::Lorem.words.join(' ')}
+    last_update               {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    open_and_vacant           {Faker::Lorem.words.join(' ')}
+    unfounded                 {Faker::Lorem.words.join(' ')}
+    after(:build) do |inspection|
+      inspection.case_number = inspection.loe_case.case_number
+    end
+  end
+
+end

--- a/test/factories/loe_cases.rb
+++ b/test/factories/loe_cases.rb
@@ -1,0 +1,35 @@
+require File.expand_path(Rails.root)+'/lib/socrata'
+FactoryGirl.define do
+  factory :loe_case do
+    ad_lot                    {Faker::Lorem.words.join(' ')}
+    ad_sakey                  {Faker::Number.between(1, 10000)}
+    ad_st_apt                 {Faker::Lorem.words.join(' ')}
+    ad_st_name                {Faker::Lorem.words.join(' ')}
+    ad_st_num                 {Faker::Lorem.words.join(' ')}
+    ad_st_type                {Faker::Lorem.words.join(' ')}
+    annex_date                {Time.now.advance(years: Faker::Number.between(1, 100)).to_date}
+    assigned_inspector_code   {Faker::Lorem.words.join(' ')}
+    assignment                {Faker::Lorem.words.join(' ')}
+    case_notes                {Faker::Lorem.paragraphs.join("\n\n")}
+    sequence(:case_number)    { |n| Time.parse("2011/01/01").advance(days: n).strftime("%Y%m%d") }
+    case_status               {Faker::Lorem.words.join(' ')}
+    case_type                 {Faker::Lorem.words.join(' ')}
+    census_tract              {Faker::Lorem.words.join(' ')}
+    close_date                {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    close_reason              {Faker::Lorem.words.join(' ')}
+    due_date                  {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    entry_date                {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    last_update               {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    origin                    {Faker::Lorem.words.join(' ')}
+    owner_mailaddr            {Faker::Address.street_address}
+    owner_mailaddr2           {Faker::Address.secondary_address}
+    owner_mailcity            {Faker::Address.city}
+    owner_mailstate           {Faker::Address.state_abbr}
+    owner_mailzip             {Faker::Address.zip}
+    owner_name                {Faker::Name.name}
+    owner_name2               {Faker::Name.name}
+    rental_status             {Faker::Lorem.words.join(' ')}
+    use_code                  {Faker::Lorem.words.join(' ')}
+    zoning                    {Faker::Lorem.words.join(' ')}
+  end
+end

--- a/test/factories/violations.rb
+++ b/test/factories/violations.rb
@@ -1,0 +1,34 @@
+FactoryGirl.define do
+  factory :violation do
+    loe_case
+    ad_st_apt               {Faker::Lorem.words.join(' ')}
+    ad_st_name              {Faker::Lorem.words.join(' ')}
+    ad_st_num               {Faker::Lorem.words.join(' ')}
+    ad_st_type              {Faker::Lorem.words.join(' ')}
+    case_number             {Faker::Number.between(1, 10000)}
+    case_sakey              {Faker::Number.between(1, 10000)}
+    clear_date              {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    cleared_by              {Faker::Lorem.words.join(' ')}
+    comments                {Faker::Lorem.paragraphs.join("\n\n")}
+    entry_date              {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    issued_by               {Faker::Lorem.words.join(' ')}
+    issued_date             {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    last_update             {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    major_violation         {Faker::Lorem.words.join(' ')}
+    number_of_items         {Faker::Number.between(1, 10000)}
+    reissue_date            {Time.now.advance(days: Faker::Number.between(1, 10000))}
+    reissued_by             {Faker::Lorem.words.join(' ')}
+    responsible_party       {Faker::Lorem.words.join(' ')}
+    violation_cleared       {Faker::Lorem.words.join(' ')}
+    violation_code          {Faker::Lorem.words.join(' ')}
+    violation_description   {Faker::Lorem.words.join(' ')}
+    violation_issued        {Faker::Lorem.words.join(' ')}
+    violation_reissued      {Faker::Lorem.words.join(' ')}
+    violation_sakey         {Faker::Number.between(1, 10000)}
+
+    after(:build) do |violation|
+      violation.case_number = violation.loe_case.case_number
+    end
+  end
+
+end

--- a/test/helpers/inspections_helper_test.rb
+++ b/test/helpers/inspections_helper_test.rb
@@ -3,11 +3,9 @@ class InspectionsHelperTest < ActionView::TestCase
   include InspectionsHelper
 
   test "unique_inspection_id" do
-    require File.expand_path(Rails.root)+'/lib/socrata'
-    socrata = Socrata.new
-    inspection = socrata.client.get(socrata.inspection_dataset_id,{'$limit': 1}).first
-    entry_date = Time.parse inspection.entry_date
-    inspection_date = Time.parse inspection.inspection_date
+    inspection = build :inspection
+    entry_date = inspection.entry_date
+    inspection_date = inspection.inspection_date
     expected = "#{inspection.case_number}*#{entry_date ? entry_date.to_i : nil}*#{inspection_date ? inspection_date.to_i : nil}"
     assert_equal expected, unique_inspection_id(inspection)
   end

--- a/test/helpers/violations_helper_test.rb
+++ b/test/helpers/violations_helper_test.rb
@@ -3,10 +3,8 @@ class ViolationsHelperTest < ActionView::TestCase
   include ViolationsHelper
 
   test "unique_violation_id" do
-    require File.expand_path(Rails.root)+'/lib/socrata'
-    socrata = Socrata.new
-    violation = socrata.client.get(socrata.violation_dataset_id,{'$limit': 1}).first
-    entry_date = Time.parse violation.entry_date
+    violation = build :violation
+    entry_date = violation.entry_date
     expected = "#{violation.case_number}*#{entry_date ? entry_date.to_i : nil}*#{violation.violation_code}"
     assert_equal expected, unique_violation_id(violation)
   end

--- a/test/models/inspection_test.rb
+++ b/test/models/inspection_test.rb
@@ -1,6 +1,11 @@
 require 'test_helper'
 
 class InspectionTest < ActiveSupport::TestCase
+
+  test "constants" do
+    assert_socrata_attribute_remapping Inspection
+  end
+
   test "factories" do
     inspection = build :inspection
     assert_kind_of Inspection, inspection

--- a/test/models/inspection_test.rb
+++ b/test/models/inspection_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class InspectionTest < ActiveSupport::TestCase
+  test "factories" do
+    inspection = build :inspection
+    assert_kind_of Inspection, inspection
+    assert inspection.valid?
+    assert inspection.save
+    assert_kind_of LoeCase, inspection.loe_case
+    assert_not_nil inspection.loe_case.case_number
+    assert_equal inspection.loe_case.case_number, inspection.case_number
+  end
+
+  test "for_case scope" do
+    assert_respond_to Inspection, :for_case
+    loe_case = create :loe_case
+    2.times do
+      create :inspection
+    end
+    expected_count = 5
+    expected_count.times do
+      create :inspection, {loe_case_id: loe_case.id}
+    end
+    inspections = Inspection.for_case(loe_case.id)
+    assert_equal expected_count, inspections.size
+    inspections.each do |inspection|
+      assert_equal loe_case.id, inspection.loe_case_id
+    end
+  end
+
+  test "assign_from_socrata" do
+    inspection = Inspection.new
+    assert_respond_to inspection, :assign_from_socrata
+    socrata = Socrata.new
+    opts = {
+      '$limit' => 1,
+      '$offset' => (0..2500).to_a.sample
+    }
+    item = socrata.client.get(Socrata.inspection_dataset_id, opts).first
+    inspection.assign_from_socrata item
+    assert_kind_of Fixnum, inspection.case_number
+  end
+end

--- a/test/models/loe_case_test.rb
+++ b/test/models/loe_case_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+class LoeCaseTest < ActiveSupport::TestCase
+  test "factories" do
+    loe_case = build :loe_case
+    assert_kind_of LoeCase, loe_case
+    assert loe_case.valid?
+    assert loe_case.save
+  end
+
+  test "assign_from_socrata" do
+    loe_case = LoeCase.new
+    assert_respond_to loe_case, :assign_from_socrata
+    socrata = Socrata.new
+    opts = {
+      '$limit' => 1,
+      '$offset' => (0..2500).to_a.sample
+    }
+    item = socrata.client.get(Socrata.case_dataset_id, opts).first
+    loe_case.assign_from_socrata item
+    assert_kind_of Fixnum, loe_case.case_number
+  end
+end

--- a/test/models/loe_case_test.rb
+++ b/test/models/loe_case_test.rb
@@ -1,5 +1,10 @@
 require 'test_helper'
 class LoeCaseTest < ActiveSupport::TestCase
+
+  test "constants" do
+    assert_socrata_attribute_remapping LoeCase
+  end
+
   test "factories" do
     loe_case = build :loe_case
     assert_kind_of LoeCase, loe_case

--- a/test/models/violation_test.rb
+++ b/test/models/violation_test.rb
@@ -2,6 +2,10 @@ require 'test_helper'
 
 class ViolationTest < ActiveSupport::TestCase
 
+  test "constants" do
+    assert_socrata_attribute_remapping Violation
+  end
+
   test "factories" do
     violation = build :violation
     assert_kind_of Violation, violation

--- a/test/models/violation_test.rb
+++ b/test/models/violation_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class ViolationTest < ActiveSupport::TestCase
+
+  test "factories" do
+    violation = build :violation
+    assert_kind_of Violation, violation
+    assert violation.valid?
+    assert violation.save
+    assert_kind_of LoeCase, violation.loe_case
+    assert_not_nil violation.loe_case.case_number
+    assert_equal violation.loe_case.case_number, violation.case_number
+  end
+
+  test "for_case scope" do
+    assert_respond_to Inspection, :for_case
+    loe_case = create :loe_case
+    2.times do
+      create :violation
+    end
+    expected_count = 5
+    expected_count.times do
+      create :violation, {loe_case_id: loe_case.id}
+    end
+    violations = Violation.for_case(loe_case.id)
+    assert_equal expected_count, violations.size
+    violations.each do |violation|
+      assert_equal loe_case.id, violation.loe_case_id
+    end
+  end
+
+  test "assign_from_socrata" do
+    violation = Violation.new
+    assert_respond_to violation, :assign_from_socrata
+    socrata = Socrata.new
+    opts = {
+      '$limit' => 1,
+      '$offset' => (0..2500).to_a.sample
+    }
+    item = socrata.client.get(Socrata.violation_dataset_id, opts).first
+    violation.assign_from_socrata item
+    assert_kind_of Fixnum, violation.case_number
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
 class ActiveSupport::TestCase
-  # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
-  fixtures :all
-
   # Add more helper methods to be used by all tests here...
+
+  include FactoryGirl::Syntax::Methods
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,4 +6,17 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
 
   include FactoryGirl::Syntax::Methods
+
+  def assert_socrata_attribute_remapping(klass)
+    assert klass.constants.include? :SOCRATA_ATTRIBUTE_REMAPPING
+    assert klass.const_get("SOCRATA_ATTRIBUTE_REMAPPING").kind_of? Hash
+    dbg = {column_names: klass.column_names.sort}
+    klass.const_get("SOCRATA_ATTRIBUTE_REMAPPING").each do |key,value|
+      dbg[:key] = key
+      dbg[:value] = value
+      assert !klass.column_names.include?(key), dbg.to_json
+      assert klass.column_names.include?(value), dbg.to_json
+    end
+  end
+
 end


### PR DESCRIPTION
Setup models and database tables to store Socrata data.  Setup `rake db:seed` to seed database with with full dump from Socrata.

The Socrata attribute names changed mid-development and there might be some database columns that I developed with the old names that need to be removed (if they are no longer in use).

Most elements are cast as strings except the ones that I could quickly and easily tell where integers, dates, floats, etc.  So there is room for more refinement.

The `:index` action now returns an `ActiveRecord_Relation` object, which cannot be cached.  Only the `:show` action is cached right now.

The `case_histories` Socrata data element started returning a 400 error on API requests and I haven't researched or fixed that.

